### PR TITLE
update package.json - update bit's config

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,12 @@
   "module": "src/index.js",
   "license": "MIT",
   "dependencies": {
-    "react": "^16.8.6",
-    "react-dom": "^16.8.6",
     "react-scripts": "3.0.1",
     "styled-components": "^4.3.2"
+  },
+  "peerDependencies": {
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6"
   },
   "repository": {
     "type": "git",
@@ -56,19 +58,6 @@
       "compiler": "bit.envs/compilers/react@1.0.2"
     },
     "componentsDefaultDirectory": "components/{name}",
-    "packageManager": "npm",
-    "overrides": {
-      "utils/sort-array": {
-        "env": {
-          "compiler": "bit.ens/compilers/babel@6.0.0"
-        }
-      },
-      "ui/*": {
-        "peerDependencies": {
-          "react": "16.8.6",
-          "react-dom": "16.8.6"
-        }
-      }
-    }
+    "packageManager": "npm"
   }
 }


### PR DESCRIPTION
This commit contain 2 different changes:
1. remove the unnecessary bit's config. the override configs as they were doesn't apply on any component so they were redundant.
2. move the react and react-dom to be peer dependencies. it's better when implementing a component library to set them as a peer.
It's also important for the bit's component.  (it can be done using the bit's override config as well, but better that way).